### PR TITLE
Allow description fields to run through XSL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,6 +52,7 @@ jobs:
           docker-image-name: ${{ vars.DOCKER_IMAGE_NAME }}
           wiz-client-id: ${{ secrets.WIZ_CLIENT_ID }}
           wiz-client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}
+          wiz-project-id: ${{ secrets.WIZ_PROJECT_DIGITALSERVICES }}
       - name: Create tag
         if: github.ref == 'refs/heads/main'
         uses: actions/github-script@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.idea/
+.vscode/
 __pycache__
 .pytest_cache
 db.sqlite3

--- a/app/lib/xslt_transformations.py
+++ b/app/lib/xslt_transformations.py
@@ -1,0 +1,22 @@
+import logging
+
+from lxml import etree, html
+
+SCHEMAS = {
+    "RoyalMarines": "app/resources/xslt/RoyalMarines_DetailScope_inc.xsl"
+}
+
+logger = logging.getLogger(__name__)
+
+
+def apply_xslt(html_source, schema):
+    dom = html.fromstring(html_source)
+    try:
+        schema_xslt = SCHEMAS[schema]
+    except KeyError:
+        logger.error(f"Schema '{schema}' not found")
+        return html_source
+    xslt = etree.parse(schema_xslt)
+    transform = etree.XSLT(xslt)
+    result = transform(dom)
+    return result

--- a/app/records/models.py
+++ b/app/records/models.py
@@ -4,6 +4,7 @@ import logging
 import re
 from typing import Any
 
+from app.lib.xslt_transformations import apply_xslt
 from app.records.constants import NON_TNA_LEVELS, TNA_LEVELS
 from app.records.utils import extract, format_extref_links, format_link
 from django.urls import NoReverseMatch, reverse
@@ -325,7 +326,13 @@ class Record(APIModel):
     @cached_property
     def description(self) -> str:
         """Returns the api value of the attr if found, empty str otherwise."""
-        return format_extref_links(self.get("description", ""))
+        description = self.get("description", "")
+        description = format_extref_links(description)
+        if self.iaid == "D7829042":  # TODO: Remove hardcoding
+            description = apply_xslt(
+                description, "RoyalMarines"  # TODO: Schema should be dynamic
+            )
+        return description
 
     @cached_property
     def separated_materials(self) -> tuple[dict[str, Any], ...]:

--- a/app/records/models.py
+++ b/app/records/models.py
@@ -330,9 +330,11 @@ class Record(APIModel):
         description = format_extref_links(description)
         if self.iaid == "D7829042":  # TODO: Remove hardcoding
             description = apply_xslt(
-                description, "RoyalMarines"  # TODO: Schema should be dynamic
+                description,
+                "RoyalMarines",  # TODO: Schema should be dynamic
             )
-        return description
+
+        return str(description)
 
     @cached_property
     def separated_materials(self) -> tuple[dict[str, Any], ...]:

--- a/app/resources/xslt/RoyalMarines_DetailScope_inc.xsl
+++ b/app/resources/xslt/RoyalMarines_DetailScope_inc.xsl
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html"/>
+  <xsl:template match="version">
+    <!--
+		VERSION CONTROL	RoyalMarines_SimpleScope_XSL XSL STYLESHEET
+	
+		###	VERSION: 1.0 	AUTHOR: CDICKSON	DATE: 08/07/2004
+		Created.
+
+    ORIGINAL: https://github.com/nationalarchives/discovery/blob/master/RDWeb/Helpers/XSLs/DoLStyles/RoyalMarines_DetailScope_inc.xsl
+		-->
+  </xsl:template>
+
+	<xsl:template match="span[@class='emph' and @altrender='doctype']">
+	</xsl:template>
+
+	<xsl:template match="/">
+    <dl class="tna-dl">
+      <xsl:apply-templates/>
+    </dl>
+	</xsl:template>
+
+  <!-- Display lastname, firstname -->
+  <xsl:template match="span[@class='persname']">
+    <dt>
+      <xsl:text disable-output-escaping="yes">Name</xsl:text>
+    </dt>
+    <dd>
+      <xsl:value-of select="span[@class='emph' and @altrender='surname']/text()"/>
+      <xsl:if test="span[@class='emph' and @altrender='surname'] and span[@class='emph' and @altrender='forenames']">
+        <xsl:text disable-output-escaping="yes">, </xsl:text>
+      </xsl:if>
+      <xsl:value-of select="span[@class='emph' and @altrender='forenames']/text()"/>
+    </dd>
+  </xsl:template>
+
+  <!-- add  age -->
+  <xsl:template match="span[@class='emph' and @altrender='num']">
+    <dt>Register number</dt>
+    <dd>
+      <xsl:value-of select="text()"/>
+    </dd>
+  </xsl:template>
+
+  <!-- add  age -->
+  <xsl:template match="span[@class='emph' and @altrender='division']">
+    <dt>Division</dt>
+    <dd>
+      <xsl:value-of select="text()"/>
+    </dd>
+  </xsl:template>
+
+  <!-- add  age -->
+  <xsl:template match="span[@class='emph' and @altrender='dob']">
+    <dt>Date of birth</dt>
+    <dd>
+      <xsl:value-of select="text()"/>
+    </dd>
+  </xsl:template>
+
+  <!-- add  age -->
+  <xsl:template match="span[@class='emph' and @altrender='date2']">
+    <dt>When enlisted/date of enlistment</dt>
+    <dd>
+      <xsl:value-of select="text()"/>
+    </dd>
+  </xsl:template>
+
+  <!-- add Date of Birth -->
+  <xsl:template match="span[@class='emph' and @altrender='dob']">
+    <dt>Date of birth</dt>
+    <dd>
+      <xsl:value-of select="text()"/>
+    </dd>
+  </xsl:template>
+</xsl:stylesheet>

--- a/poetry.lock
+++ b/poetry.lock
@@ -139,24 +139,24 @@ files = [
 
 [[package]]
 name = "cssselect"
-version = "1.2.0"
+version = "1.3.0"
 description = "cssselect parses CSS3 Selectors and translates them to XPath 1.0"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "cssselect-1.2.0-py2.py3-none-any.whl", hash = "sha256:da1885f0c10b60c03ed5eccbb6b68d6eff248d91976fcde348f395d54c9fd35e"},
-    {file = "cssselect-1.2.0.tar.gz", hash = "sha256:666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc"},
+    {file = "cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d"},
+    {file = "cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7"},
 ]
 
 [[package]]
 name = "django"
-version = "5.1.6"
+version = "5.1.7"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "Django-5.1.6-py3-none-any.whl", hash = "sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5"},
-    {file = "Django-5.1.6.tar.gz", hash = "sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690"},
+    {file = "Django-5.1.7-py3-none-any.whl", hash = "sha256:1323617cb624add820cb9611cdcc788312d250824f92ca6048fda8625514af2b"},
+    {file = "Django-5.1.7.tar.gz", hash = "sha256:30de4ee43a98e5d3da36a9002f287ff400b43ca51791920bfb35f6917bfe041c"},
 ]
 
 [package.dependencies]
@@ -217,13 +217,13 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
 
 [[package]]
@@ -710,13 +710,13 @@ fixture = ["fixtures"]
 
 [[package]]
 name = "responses"
-version = "0.25.6"
+version = "0.25.7"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "responses-0.25.6-py3-none-any.whl", hash = "sha256:9cac8f21e1193bb150ec557875377e41ed56248aed94e4567ed644db564bacf1"},
-    {file = "responses-0.25.6.tar.gz", hash = "sha256:eae7ce61a9603004e76c05691e7c389e59652d91e94b419623c12bbfb8e331d8"},
+    {file = "responses-0.25.7-py3-none-any.whl", hash = "sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c"},
+    {file = "responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb"},
 ]
 
 [package.dependencies]
@@ -729,13 +729,13 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "sentry-sdk"
-version = "2.22.0"
+version = "2.24.1"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "sentry_sdk-2.22.0-py2.py3-none-any.whl", hash = "sha256:3d791d631a6c97aad4da7074081a57073126c69487560c6f8bffcf586461de66"},
-    {file = "sentry_sdk-2.22.0.tar.gz", hash = "sha256:b4bf43bb38f547c84b2eadcefbe389b36ef75f3f38253d7a74d6b928c07ae944"},
+    {file = "sentry_sdk-2.24.1-py2.py3-none-any.whl", hash = "sha256:36baa6a1128b9d98d2adc5e9b2f887eff0a6af558fc2b96ed51919042413556d"},
+    {file = "sentry_sdk-2.24.1.tar.gz", hash = "sha256:8ba3c29990fa48865b908b3b9dc5ae7fa7e72407c7c9e91303e5206b32d7b8b1"},
 ]
 
 [package.dependencies]
@@ -814,13 +814,13 @@ Jinja2 = ">=3"
 
 [[package]]
 name = "tzdata"
-version = "2025.1"
+version = "2025.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
-    {file = "tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694"},
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
 
 [[package]]
@@ -857,4 +857,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "7e5ede7a5203b59c49b68da0ab0c745da26ca7f669812eac45fabbad896aedd5"
+content-hash = "8ac6523a5004d39fafaedc585c51909765092fd067bf187732276f9ae469c99a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -932,4 +932,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "48af44274eeba64a9f5945fb4f85d4c36dc1dcf55fdbd03794e181d96383f8a3"
+content-hash = "550cdaed3edfb9f7cbc0ba61596d5754ae92cd15020859da5ac25c9937585b79"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ whitenoise = "^6.7.0"
 responses = "^0.25.3"
 pyquery = "^2.0.1"
 sentry-sdk = "^2.20.0"
+lxml = "^5.3.1"
 
 [tool.poetry.group.dev]
 optional = true

--- a/test/lib/test_xslt_transformations.py
+++ b/test/lib/test_xslt_transformations.py
@@ -1,0 +1,28 @@
+import unittest
+
+from app.lib.xslt_transformations import apply_xslt
+from lxml import html
+
+
+class ContentParserTestCase(unittest.TestCase):
+    def test_RoyalMarines(self):
+        self.maxDiff = None
+        # D7829042
+        source = '<span class="wrapper"><span altrender="doctype" class="emph"></span><span class="persname"><span altrender="surname" class="emph">Hillyard</span><span altrender="forenames" class="emph">Ernest Percy</span></span><span altrender="num" class="emph">21311</span><span altrender="division" class="emph">Royal Marine Light Infantry: Plymouth Division</span><span altrender="date2" class="emph">01 October 1918</span><span altrender="dob" class="emph">09 October 1900</span></span>'
+        schema = "RoyalMarines"
+        self.assertEqual(
+            """<dl class="tna-dl">
+<dt>Name</dt>
+<dd>Hillyard, Ernest Percy</dd>
+<dt>Register number</dt>
+<dd>21311</dd>
+<dt>Division</dt>
+<dd>Royal Marine Light Infantry: Plymouth Division</dd>
+<dt>When enlisted/date of enlistment</dt>
+<dd>01 October 1918</dd>
+<dt>Date of birth</dt>
+<dd>09 October 1900</dd>
+</dl>
+""",
+            str(apply_xslt(source, schema)),
+        )

--- a/test/lib/test_xslt_transformations.py
+++ b/test/lib/test_xslt_transformations.py
@@ -6,7 +6,6 @@ from lxml import html
 
 class ContentParserTestCase(unittest.TestCase):
     def test_RoyalMarines(self):
-        self.maxDiff = None
         # D7829042
         source = '<span class="wrapper"><span altrender="doctype" class="emph"></span><span class="persname"><span altrender="surname" class="emph">Hillyard</span><span altrender="forenames" class="emph">Ernest Percy</span></span><span altrender="num" class="emph">21311</span><span altrender="division" class="emph">Royal Marine Light Infantry: Plymouth Division</span><span altrender="date2" class="emph">01 October 1918</span><span altrender="dob" class="emph">09 October 1900</span></span>'
         schema = "RoyalMarines"


### PR DESCRIPTION
Test record page: http://localhost:65533/catalogue/id/D7829042/

- `app/resources/xslt/RoyalMarines_DetailScope_inc.xsl` is just temporarily different from https://github.com/nationalarchives/discovery/blob/master/RDWeb/Helpers/XSLs/DoLStyles/RoyalMarines_DetailScope_inc.xsl until the description values are updated in Rosetta
- The `SCHEMAS` will be updated later with a more comprehensive list

To test this change, you have to rebuild Docker to install the new `lxml` dependency: `docker compose up --build -d app`