### PR TITLE
FIND-226: Add closure status filter

### DIFF
--- a/app/records/constants.py
+++ b/app/records/constants.py
@@ -21,3 +21,9 @@ NON_TNA_LEVELS = {
     "10": "Item",
     "11": "Sub-item",
 }
+
+CLOSURE_STATUSES = {
+    "1": "Closed Or Retained Document, Closed Description",
+    "2": "Closed Or Retained Document, Open Description",
+    "3": "Open Document, Open Description",
+}

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -3,7 +3,7 @@ import math
 from app.errors import views as errors_view
 from app.lib.api import ResourceNotFound
 from app.lib.pagination import pagination_object
-from app.records.constants import TNA_LEVELS
+from app.records.constants import TNA_LEVELS, CLOSURE_STATUSES
 from app.search.api import search_records
 from config.jinja2 import qs_remove_value, qs_toggle_value
 from django.template.response import TemplateResponse
@@ -15,6 +15,7 @@ def catalogue_search_view(request):
     template = "search/catalogue.html"
     context: dict = {
         "levels": TNA_LEVELS,
+        "closure_statuses": CLOSURE_STATUSES,
     }
     results_per_page = 20
     page = int(request.GET.get("page", 1))
@@ -117,6 +118,15 @@ def build_selected_filters_list(request):
                     "label": f"Level: {TNA_LEVELS.get(level)}",
                     "href": f"?{qs_toggle_value(request.GET, 'level', level)}",
                     "title": f"Remove {TNA_LEVELS.get(level)} level",
+                }
+            )
+    if closure_statuses := request.GET.getlist("closure_status", None):
+        for closure_status in closure_statuses:
+            selected_filters.append(
+                {
+                    "label": f"Closure status: {CLOSURE_STATUSES.get(closure_status)}",
+                    "href": f"?{qs_toggle_value(request.GET, 'status', closure_status)}",
+                    "title": f"Remove {CLOSURE_STATUSES.get(closure_status)} closure status",
                 }
             )
     return selected_filters

--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -16,6 +16,7 @@
 {% from 'search/macros/filters/search_within.html' import search_within %}
 {% from 'search/macros/filters/date_range.html' import date_range %}
 {% from 'search/macros/filters/levels_tna.html' import levels_tna %}
+{% from 'search/macros/filters/closure_statuses_tna.html' import closure_statuses_tna %}
 
 {%- set pageTitle = 'Catalogue search results' -%}
 {%- set encodedQuery = request.GET.urlencode() | base64_encode -%}
@@ -106,6 +107,7 @@
     {{ search_within(request) }}
     {{ date_range(request, 'date', 'date', 'Filter by record date') }}
     {{ levels_tna(request, levels) }}
+    {{ closure_statuses_tna(request, closure_statuses) }}
   </div>
   {% if results %}
   <div id="results" class="tna-column tna-column--width-3-4 tna-column--width-2-3-medium tna-column--full-small tna-column--full-tiny tna-!--margin-top-l">

--- a/app/templates/search/macros/filters/closure_statuses_tna.html
+++ b/app/templates/search/macros/filters/closure_statuses_tna.html
@@ -1,0 +1,38 @@
+{% from 'components/button/macro.html' import tnaButton %}
+{% from 'components/checkboxes/macro.html' import tnaCheckboxes %}
+
+{% macro closure_statuses_tna(request, statuses) %}
+<div class="tna-aside tna-aside--tight tna-background-tint tna-!--margin-top-s">
+  {% set closure_statuses = [] %}
+  {% for status_id, status in statuses.items() %}
+    {% set closure_statuses = closure_statuses.append({
+      'text': status,
+      'value': status_id,
+      'checked': qs_is_value_active(request.GET, 'closure_status', status_id)
+    }) %}
+  {% endfor %}
+  {{ tnaCheckboxes({
+    'label': 'Closure status',
+    'headingLevel': 3,
+    'headingSize': 'm',
+    'id': 'closure_status',
+    'name': 'closure_status',
+    'items': closure_statuses,
+    'small': True,
+    'attributes': {
+      'form': 'search-form'
+    }
+  }) }}
+  <div class="tna-button-group tna-!--margin-top-s">
+    {{ tnaButton({
+      'text': 'Update',
+      'buttonElement': True,
+      'buttonType': 'submit',
+      'small': True,
+      'attributes': {
+        'form': 'search-form'
+      }
+    }) }}
+  </div>
+</div>
+{% endmacro %}


### PR DESCRIPTION
# Pull Request

[FIND-226: Add closure status filter box](https://national-archives.atlassian.net/browse/FIND-226)

## About these changes

Introduces an additional filter to the search results page reflecting the content shown in designs[^1] and linking the checked state to relevant values in the query string.  

<details open>
<summary>Screenshot of filter in page</summary>

<img width="489" alt="Screenshot of new closure status filter" src="https://github.com/user-attachments/assets/d9cb8e95-6918-48ce-bcac-a7f408816ca9" />

</details>

[^1]: http://localhost:65533/catalogue/search/?q=*&display=&group=&search_within=&date_from=&date_to=&sort=

## How to check these changes

You can check these changes by following these steps having cloned and run this branch locally:

1. Visit the search results page (for example, by clicking [this link](http://localhost:65533/catalogue/search/?q=%22MI5%22)) to confirm you're presented with the closure status filters
1. Compare the closure status filter to [the designs](https://snapshot-2025-04-17-vw7zhsi-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/)
1. Select a closure status filter and click the "Update" button to check that the refreshed page shows the filter checked 

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review (two jobs - `update-dblclk (push)` and `update-ds-infrastructure-web (push)` were skipped but it seems these only run on `main`)
- [x] Added/updated tests and documentation where relevant (I've referenced [the commit](https://github.com/nationalarchives/ds-search/commit/d4649d6310ebcae45d9cebd47fcfedac7bb78236#diff-abfa2bcfdef8c3a3da7a63785ec7f9a228f17c4fa3c368ecb86d66506ea045ce) introducing a similar filter and have tried to follow the implementation approach used there)
