### PR TITLE
FIND-227: Add collections filter

### DIFF
--- a/app/records/constants.py
+++ b/app/records/constants.py
@@ -27,3 +27,8 @@ CLOSURE_STATUSES = {
     "2": "Closed Or Retained Document, Open Description",
     "3": "Open Document, Open Description",
 }
+
+COLLECTIONS = {
+    "1": "WO - War Office, Armed Forces, Judge Advocate General, and related bodies",
+    "2": "BT - Board of Trade and successors",
+}

--- a/app/search/views.py
+++ b/app/search/views.py
@@ -3,7 +3,7 @@ import math
 from app.errors import views as errors_view
 from app.lib.api import ResourceNotFound
 from app.lib.pagination import pagination_object
-from app.records.constants import CLOSURE_STATUSES, TNA_LEVELS
+from app.records.constants import TNA_LEVELS, CLOSURE_STATUSES, COLLECTIONS
 from app.search.api import search_records
 from config.jinja2 import qs_remove_value, qs_toggle_value
 from django.template.response import TemplateResponse
@@ -16,6 +16,7 @@ def catalogue_search_view(request):
     context: dict = {
         "levels": TNA_LEVELS,
         "closure_statuses": CLOSURE_STATUSES,
+        "collections": COLLECTIONS,
     }
     results_per_page = 20
     page = int(request.GET.get("page", 1))
@@ -127,6 +128,15 @@ def build_selected_filters_list(request):
                     "label": f"Closure status: {CLOSURE_STATUSES.get(closure_status)}",
                     "href": f"?{qs_toggle_value(request.GET, 'closure_status', closure_status)}",
                     "title": f"Remove {CLOSURE_STATUSES.get(closure_status)} closure status",
+                }
+            )
+    if collections := request.GET.getlist("collections", None):
+        for collection in collections:
+            selected_filters.append(
+                {
+                    "label": f"Collection: {COLLECTIONS.get(collection)}",
+                    "href": f"?{qs_toggle_value(request.GET, 'collections', collection)}",
+                    "title": f"Remove {COLLECTIONS.get(collection)} collection",
                 }
             )
     return selected_filters

--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -18,6 +18,7 @@
 {% from 'search/macros/filters/levels_tna.html' import levels_tna %}
 {% from 'search/macros/filters/closure_statuses_tna.html' import closure_statuses_tna %}
 {% from 'search/macros/filters/opening_date.html' import opening_date %}
+{% from 'search/macros/filters/collections_tna.html' import collections_tna %}
 
 {%- set pageTitle = 'Catalogue search results' -%}
 {%- set encodedQuery = request.GET.urlencode() | base64_encode -%}
@@ -114,6 +115,7 @@
     {{ levels_tna(request, levels) }}
     {{ closure_statuses_tna(request, closure_statuses) }}
     {{ date_range(request, 'date', 'date', 'Filter by record opening date') }}
+    {{ collections_tna(request, collections) }}
   </div>
   {% if results %}
   <div id="results" class="tna-column tna-column--width-3-4 tna-column--width-2-3-medium tna-column--full-small tna-column--full-tiny tna-!--margin-top-l">

--- a/app/templates/search/macros/filters/collections_tna.html
+++ b/app/templates/search/macros/filters/collections_tna.html
@@ -1,0 +1,38 @@
+{% from 'components/button/macro.html' import tnaButton %}
+{% from 'components/checkboxes/macro.html' import tnaCheckboxes %}
+
+{% macro collections_tna(request, collection) %}
+<div class="tna-aside tna-aside--tight tna-background-tint tna-!--margin-top-s">
+  {% set collections = [] %}
+  {% for collection_id, collection in collection.items() %}
+    {% set collections = collections.append({
+      'text': collection,
+      'value': collection_id,
+      'checked': qs_is_value_active(request.GET, 'collections', collection_id)
+    }) %}
+  {% endfor %}
+  {{ tnaCheckboxes({
+    'label': 'Collections',
+    'headingLevel': 3,
+    'headingSize': 'm',
+    'id': 'collections',
+    'name': 'collections',
+    'items': collections,
+    'small': True,
+    'attributes': {
+      'form': 'search-form'
+    }
+  }) }}
+  <div class="tna-button-group tna-!--margin-top-s">
+    {{ tnaButton({
+      'text': 'Update',
+      'buttonElement': True,
+      'buttonType': 'submit',
+      'small': True,
+      'attributes': {
+        'form': 'search-form'
+      }
+    }) }}
+  </div>
+</div>
+{% endmacro %}


### PR DESCRIPTION
Introduces changes described in [FIND-227](https://national-archives.atlassian.net/browse/FIND-227)

## About these changes

Introduces an additional filter to the search results page, initially populated with some dummy data based on the subjects shown for TNA records results in Discovery [^1]. Uses the same approach as other filters to pick up any selected filters from the request.

<details open>

<summary>Screenshot of new filter in page</summary>

![Screenshot of the collections filter](https://github.com/user-attachments/assets/43c6977a-1c15-41b6-a3be-daa7c79b7cdf)

</details>

[^1]: For example https://discovery.nationalarchives.gov.uk/results/r?_hb=tna&_q=*

## How to check these changes

You can check these changes by following these steps when running this branch locally:

1. Visit the search results page (for example, by clicking [this link](http://localhost:65533/catalogue/search/?q=%22MI5%22)) to confirm you're presented with the collections filter
1. Select a collection and click the "Update" button to check that the refreshed page:
    a. shows the filter as checked
    b. has included the selected filter in the list of applied filters

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant


[FIND-227]: https://national-archives.atlassian.net/browse/FIND-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ