### PR TITLE
FIX: Fixes bug introduced in FIND-226

### DIFF
--- a/app/search/views.py
+++ b/app/search/views.py
@@ -125,7 +125,7 @@ def build_selected_filters_list(request):
             selected_filters.append(
                 {
                     "label": f"Closure status: {CLOSURE_STATUSES.get(closure_status)}",
-                    "href": f"?{qs_toggle_value(request.GET, 'status', closure_status)}",
+                    "href": f"?{qs_toggle_value(request.GET, 'closure_status', closure_status)}",
                     "title": f"Remove {CLOSURE_STATUSES.get(closure_status)} closure status",
                 }
             )


### PR DESCRIPTION
Fixes a bug introduced in the PR for FIND-226 [^1]

## About these changes

The previous PR [^2] introduced the Closure Status filter box and linked the selection of a Closure Status to the list of applied filters. I've since noticed that the link within the applied filter lozenge wasn't clearing the filter, and traced this to me having passed an incorrect value. This PR fixes that bug.

[^1]: https://national-archives.atlassian.net/browse/FIND-226
[^2]: https://github.com/nationalarchives/ds-search/pull/37

## How to check these changes

1. Verify the presence of the bug on `main` by clicking the 🆇 which appears in the lozenge on [this page](http://localhost:65533/catalogue/search/?q=testing&display=&group=&search_within=&date_from=&date_to=&closure_status=3&sort=). This should clear the filter, but is not doing that. 
2. Switch to this branch and you should find that the 🆇 works as expected.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant
