### PR TITLE
Fix/find 245 fix bucket default when search term changed from results page

### DIFF
--- a/app/search/views.py
+++ b/app/search/views.py
@@ -22,7 +22,7 @@ def catalogue_search_view(request):
     sort = sort_order[0] if sort_order else ""
     order = sort_order[1] if len(sort_order) > 1 else ""
 
-    current_bucket_key = request.GET.get("group", BucketKeys.TNA)
+    current_bucket_key = request.GET.get("group") or BucketKeys.TNA
     # filter records for a bucket
     params = {"filter": f"group:{current_bucket_key}"}
 


### PR DESCRIPTION
# Pull Request

https://national-archives.atlassian.net/browse/FIND-245

## About these changes

In the search url, the group could have a value of an empty string, so checking for null was failing to default to 'tna' correctly.

## How to check these changes

On search landing page, enter a search term. On results page, click on one of the buckets and compare the search result total with that in the bucket. Then enter another search. The group parameter should remain in the same bucket as before, and the results should only show matches from that bucket.

