### PR TITLE
Add redirects for beta.nationalarchives.gov.uk to live site

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -15,35 +15,67 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from urllib.parse import urljoin
+
 from app.errors import views as errors_view
 from app.records import converters
 from django.apps import apps
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path, register_converter
+from django.http import HttpResponseRedirect
+from django.urls import include, path, re_path, register_converter
 
 register_converter(converters.IDConverter, "id")
 
 handler404 = "app.errors.views.page_not_found_error_view"
 
-urlpatterns = [
-    path("", include(("app.main.urls", "main"), namespace="main")),
-    path("healthcheck/", include("app.healthcheck.urls")),
-    path(
-        "catalogue/",
-        include(("app.search.urls", "search"), namespace="search"),
-    ),
-    path(
-        "catalogue/",
-        include(("app.records.urls", "records"), namespace="records"),
-    ),
-    path(
-        "404/",
-        errors_view.page_not_found_error_view,
-    ),
-    path("admin/", admin.site.urls),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+# ==========================================
+# beta.nationalarchives.gov.uk redirects
+# ------------------------------------------
+# When this service is hosted using the beta
+# subdomain it will have to handle redirects
+# for any content that used to be accessible
+# through the subdomain, and forward them on
+# to the live site.
+# These routes should be removed after about
+# 6 months, at the start of December 2025.
+# ==========================================
+def redirectToLiveSite(request):
+    new_url = urljoin("https://www.nationalarchives.gov.uk", request.path)
+    return HttpResponseRedirect(new_url)
+
+
+old_beta_site_redirect_urls = [
+    re_path(r"^explore-the-collection/.*$", redirectToLiveSite),
+    re_path(r"^people/.*$", redirectToLiveSite),
+]
+# ==========================================
+# END beta.nationalarchives.gov.uk redirects
+# ==========================================
+
+urlpatterns = (
+    [
+        path("", include(("app.main.urls", "main"), namespace="main")),
+        path("healthcheck/", include("app.healthcheck.urls")),
+        path(
+            "catalogue/",
+            include(("app.search.urls", "search"), namespace="search"),
+        ),
+        path(
+            "catalogue/",
+            include(("app.records.urls", "records"), namespace="records"),
+        ),
+        path(
+            "404/",
+            errors_view.page_not_found_error_view,
+        ),
+        path("admin/", admin.site.urls),
+    ]
+    + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    + old_beta_site_redirect_urls
+)
 
 if apps.is_installed("debug_toolbar"):
     urlpatterns = [


### PR DESCRIPTION
This change is temporary but will allow us to point beta.nationalarchives.gov.uk at this service more quickly and not break bookmarks or old links from the previous iteration of the beta subdomain, giving us an AWS-hosted platform to test with.

After about 6 months, these redirect routes (`old_beta_site_redirect_urls`) should be removed.