### PR TITLE
Feature/find 259 replace digitised bucket with filter

### DIFF
--- a/app/search/buckets.py
+++ b/app/search/buckets.py
@@ -44,7 +44,6 @@ class BucketKeys(StrEnum):
     """
 
     TNA = "tna"
-    DIGITISED = "digitised"
     NONTNA = "nonTna"
 
 
@@ -82,11 +81,6 @@ CATALOGUE_BUCKETS = BucketList(
             key=BucketKeys.TNA.value,
             label="Records at the National Archives",
             description="Results for records held at The National Archives that match your search term.",
-        ),
-        Bucket(
-            key=BucketKeys.DIGITISED.value,
-            label="Online records at The National Archives",
-            description="Results for records available to download and held at The National Archives that match your search term.",
         ),
         Bucket(
             key=BucketKeys.NONTNA.value,

--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -19,6 +19,7 @@
 {% from 'search/macros/filters/closure_statuses_tna.html' import closure_statuses_tna %}
 {% from 'search/macros/filters/opening_date.html' import opening_date %}
 {% from 'search/macros/filters/collections_tna.html' import collections_tna %}
+{% from 'search/macros/filters/online_tna.html' import online_tna %}
 
 {%- set pageTitle = 'Catalogue search results' -%}
 {%- set encodedQuery = request.GET.urlencode() | base64_encode -%}
@@ -110,6 +111,7 @@
             }) }}
         </div>
     {% endif %}
+    {{ online_tna(request) }}
     {{ search_within(request) }}
     {{ date_range(request, 'date', 'date', 'Filter by record date') }}
     {{ levels_tna(request, levels) }}

--- a/app/templates/search/macros/filters/online_tna.html
+++ b/app/templates/search/macros/filters/online_tna.html
@@ -1,0 +1,36 @@
+{% from 'components/button/macro.html' import tnaButton %}
+{% from 'components/checkboxes/macro.html' import tnaCheckboxesElement %}
+
+{% macro online_tna(request) %}
+    {% set is_tna_results_page = request.GET.get('group') in [None, 'tna'] %}
+    {% if is_tna_results_page %}
+        <div class="tna-aside tna-aside--tight tna-background-accent-light tna-!--margin-top-s">
+            {{ tnaCheckboxesElement({
+            'id': 'online',
+            'name': 'online',
+            'items': [
+              {
+                'text': 'Show online records only',
+                'value': 'true',
+                'checked': request.GET.get('online') == 'true'
+              }
+            ],
+            'small': True,
+            'attributes': {
+              'form': 'search-form'
+            }
+          }) }}
+            <div class="tna-button-group tna-!--margin-top-s">
+                {{ tnaButton({
+              'text': 'Update',
+              'buttonElement': True,
+              'buttonType': 'submit',
+              'small': True,
+              'attributes': {
+                'form': 'search-form'
+              }
+            }) }}
+            </div>
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/test/search/test_buckets.py
+++ b/test/search/test_buckets.py
@@ -29,7 +29,6 @@ class TestBuckets(TestCase):
                         {"value": "record", "count": 37470380},
                         {"value": "tna", "count": 26008838},
                         {"value": "nonTna", "count": 16454377},
-                        {"value": "digitised", "count": 9055592},
                         {"value": "medalCard", "count": 5481173},
                         {"value": "will", "count": 1016334},
                         {"value": "aggregation", "count": 763209},
@@ -69,32 +68,6 @@ class TestBuckets(TestCase):
                         "current": True,
                     },
                     {
-                        "name": "Online records at The National Archives (9,055,592)",
-                        "href": "?group=digitised",
-                        "current": False,
-                    },
-                    {
-                        "name": "Records at other UK archives (16,454,377)",
-                        "href": "?group=nonTna",
-                        "current": False,
-                    },
-                ],
-            ),
-            (
-                "DIGITISED",
-                BucketKeys.DIGITISED,
-                [
-                    {
-                        "name": "Records at the National Archives (26,008,838)",
-                        "href": "?group=tna",
-                        "current": False,
-                    },
-                    {
-                        "name": "Online records at The National Archives (9,055,592)",
-                        "href": "?group=digitised",
-                        "current": True,
-                    },
-                    {
                         "name": "Records at other UK archives (16,454,377)",
                         "href": "?group=nonTna",
                         "current": False,
@@ -128,11 +101,6 @@ class TestBuckets(TestCase):
                     "name": "Records at the National Archives (26,008,838)",
                     "href": "?group=tna&q=ufo",
                     "current": True,
-                },
-                {
-                    "name": "Online records at The National Archives (9,055,592)",
-                    "href": "?group=digitised&q=ufo",
-                    "current": False,
                 },
                 {
                     "name": "Records at other UK archives (16,454,377)",

--- a/test/search/test_views.py
+++ b/test/search/test_views.py
@@ -3,6 +3,7 @@ from app.records.models import Record
 from app.search.buckets import BucketKeys
 from django.conf import settings
 from django.test import TestCase
+from django.utils.encoding import force_str
 
 
 class CatalogueSearchViewTests(TestCase):
@@ -83,3 +84,17 @@ class CatalogueSearchViewTests(TestCase):
             ],
         )
         self.assertEqual(response.context_data.get("bucket_keys"), BucketKeys)
+
+        # Assert for presence of the unchecked online checkbox in the HTML response
+        html = force_str(response.content)
+        self.assertIn('name="online"', html)
+        self.assertNotIn('name="online" checked', html)
+
+        # Assert for presence of checked online checkbox where request parameter is set
+        response_checked = self.client.get("/catalogue/search/?online=true")
+        html_checked = force_str(response_checked.content)
+        self.assertIn('name="online" checked', html_checked)
+
+        # Assert the online checkbox is not included if group is set to 'nonTna'
+        non_tna_response = self.client.get("/catalogue/search/?group=nonTna")
+        self.assertNotIn('name="online"', non_tna_response.content.decode())

--- a/test/search/test_views.py
+++ b/test/search/test_views.py
@@ -76,11 +76,6 @@ class CatalogueSearchViewTests(TestCase):
                     "current": True,
                 },
                 {
-                    "name": "Online records at The National Archives (0)",
-                    "href": "?group=digitised",
-                    "current": False,
-                },
-                {
                     "name": "Records at other UK archives (0)",
                     "href": "?group=nonTna",
                     "current": False,


### PR DESCRIPTION
## About these changes

This PR introduces the frontend (only) changes to replace the digitised bucket (which had been presented as a tab on the search results page) with a checkbox filter. More detail is provided in the [Jira ticket](https://national-archives.atlassian.net/browse/FIND-259).

<details>
  <summary>Screenshot before</summary>

Note that there's a tab for "Online records at The National Archives" 👇🏼

![Screenshot of the page before](https://github.com/user-attachments/assets/cee7c599-421d-40de-bf6f-62d6d3053475)

</details>

<details>
  <summary>Screenshot after</summary>

Note that the tab has been replaced with a checkbox filter 👇🏼

![Screenshot of the page after](https://github.com/user-attachments/assets/959bec45-252a-4958-b8ef-9c0541f96286)

</details>

There are a few things to note about the new filter:

1. It is only included in the results page for TNA records. This has been achieved with a conditional in the new macro which checks the request for either the absence of `group` (in which case search results default to TNA) or `tna` having been explicitly set. In some ways, this is not ideal because the filter will not be shown if the user were to hack the URL so that `group` is, say, `chicken` - but it feels less brittle than logic to check the group is _not_, say, `nonTna` (I'm very happy to change this, though). 
1. Having mentioned at stand-up that [ the design ](https://www.figma.com/proto/YVFPU9zQzYwHmuygVE970Z/NuSearch-wireframes?page-id=5436%3A3717&node-id=5439-4409&p=f&viewport=-142%2C-237%2C1&t=vdv4ijXjx4jhhaNh-1&scaling=scale-down-width&content-scaling=fixed&starting-point-node-id=5436%3A3728) does not include an 'Update' button, it was suggested I include a button as there is a decision to be made in future about the use of multiple 'Update' buttons. 
1. Rather than using `tnaCheckboxes` with additional CSS to hide the `legend`, I've used `tnaCheckboxesElement`  because my sense is we do not need the `fieldset` and `legend` where there is a single field. This view seems to be supported by a blog post by Leonie Watson [^1].

[^1]: GDS have a blog post which explains you should not use legend
      and fieldset for a single form field: https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/

## How to check these changes

Having cloned and run the branch locally: 

1. Visit [the catalogue search home page](http://localhost:65533/catalogue/) and submit a basic search 
2. Confirm that the 'Show online records only' filter is shown on [the results page](http://localhost:65533/catalogue/search/?q=search)
3. Check the 'Show online records only' checkbox and click 'Update'
4. Confirm that the 'Show online records only' filter is checked on [the results page](http://localhost:65533/catalogue/search/?q=search&display=list&online=true&search_within=&date_from=&date_to=&date_from=&date_to=&sort=)
5. Click the 'Records at other UK archives' tab
6. Confirm that the 'Show online records only' checkbox is not shown on [the results page](http://localhost:65533/catalogue/search/?group=nonTna&q=search)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant
