### PR TITLE
FIND-259: Tweak online checkbox label

### DIFF
--- a/app/templates/search/macros/filters/online_tna.html
+++ b/app/templates/search/macros/filters/online_tna.html
@@ -10,7 +10,7 @@
             'name': 'online',
             'items': [
               {
-                'text': 'Show online records only',
+                'text': 'Show only records available online',
                 'value': 'true',
                 'checked': request.GET.get('online') == 'true'
               }


### PR DESCRIPTION
## About these changes

The work described in [FIND-259](https://national-archives.atlassian.net/browse/FIND-259) was introduced #52, which has been approved and merged. This morning, a _tiny_ request came through from the Product Manager in conversation with Content Designers to tweak the label content slightly. 

## How to check these changes

It's a tiny content change, so might not warrant a manual check but here's how you could manually test: 

1. Clone and run this branch locally
2. Visit [the search results page](http://localhost:65533/catalogue/search/?q=testing) and confirm that the online results filter label text is "Show only records available online"

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant


[FIND-259]: https://national-archives.atlassian.net/browse/FIND-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ