### PR TITLE
Fix "Skip to results" link 

### DIFF
--- a/app/templates/search/catalogue.html
+++ b/app/templates/search/catalogue.html
@@ -32,8 +32,8 @@
 {% block skipLink %}
 {% if results %}
 {{ tnaSkipLink({
-  href: 'results',
-  text: 'Skip to results'
+  'href': 'results',
+  'text': 'Skip to results'
 }) }}
 {% endif %}
 {{ super() }}


### PR DESCRIPTION
## Jira ticket

There's no Jira ticket for this - it's just a quick bug fix. I'd be happy to create one though, if that would be helpful. 

## About these changes

### Fixing the bug

Having mentioned a finding from the DAC audit of Discovery that proposed the inclusion of 'Skip to results' link on search results pages (as a mechanism that would allow users to quickly bypass search filters etc.), I learned that this had already been considered for Etna Catalogue and a link introduced.

I was curious to see how this would appear so tested it and found that the results page had two 'Skip to main content' links, despite the correct keys being passed to the component. Having done a bit of experimentation, it seems the component was falling back to defaults because the dictionary keys weren't quoted. The fix was simply quoting the keys.

## How to check these changes

To manually test these changes:

- Clone this branch and visit the catalogue search page. 
- Using keyboard tab navigation should reveal a "Skip to main content" link (only)
- Perform a search
- Using keyboard tab navigation should also reveal a "Skip to results" link

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x]  Ensured that PR includes only commits relevant to the ticket
- [x]  Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant
